### PR TITLE
Add option to configure udp source port.

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -148,6 +148,10 @@
 				<input type="number" class="value" id="searchInterval" min="0"/>
 				<label for="searchInterval" class="translate">Search interval</label>
 			</div>
+			<div class="col s6 input-field">
+				<input type="number" class="value" id="sourcePort" min="0"/>
+				<label for="sourcePort" class="translate">Source port [UDP] for SSDP client (0 = automatic)</label>
+			</div>
 		</div>
 
 	</div>

--- a/io-package.json
+++ b/io-package.json
@@ -317,7 +317,8 @@
         "autoPlayCmd": "set_group_volume&level=15|play_preset&preset=1",
         "volumeStepLevel": 2,
         "queueMode": 4,
-        "cmdScope": "leader"
+        "cmdScope": "leader",
+        "sourcePort": 0
     },
     "objects": [],
     "instanceObjects": [

--- a/main.js
+++ b/main.js
@@ -2404,7 +2404,7 @@ class Heos extends utils.Adapter {
 			}
 			this.ssdp_player_ips = [];
 			this.logInfo('searching for HEOS devices ...', true);
-			this.nodessdp_client = new NodeSSDP();
+			this.nodessdp_client = new NodeSSDP({'sourcePort': this.config.sourcePort});
 			this.nodessdp_client.explicitSocketBind = true;
 			this.nodessdp_client.on('response', (headers, statusCode, rinfo) => this.onNodeSSDPResponse(headers, statusCode, rinfo));
 			this.nodessdp_client.on('error', error => { this.nodessdp_client.close(); this.logError('[nodessdp] ' + error, false); });


### PR DESCRIPTION
This port is used for listening for responses to the SSDP search (device
discovers) and thus incoming packets to this port may not be blocked by
the firewall. Configuring a fixed port allows to define a specific rule
for this service instead of allowing all incoming UDP traffic.